### PR TITLE
Add our microcode hook by default

### DIFF
--- a/src/modules/initcpiocfg/main.py
+++ b/src/modules/initcpiocfg/main.py
@@ -86,7 +86,7 @@ def modify_mkinitcpio_conf(partitions, root_mount_point):
     cpu = cpuinfo()
     swap_uuid = ""
     btrfs = ""
-    hooks = ["base", "udev", "autodetect", "modconf", "block", "keyboard", "keymap"]
+    hooks = ["base", "udev", "autodetect", "modconf", "block", "keyboard", "keymap", "microcode"]
     modules = []
 
     # It is important that the plymouth hook comes before any encrypt hook


### PR DESCRIPTION
Chakra's intel-ucode just reverted to the microcode file method. The left necessary part is to make calamares use this hook by default.
